### PR TITLE
impl: 話題のレシピ一覧参照エンドポイントの実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,6 @@ RSpec/ContextWording:
 
 RSpec/NamedSubject:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,12 @@ Rails/I18nLocaleTexts:
 
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,10 +1,5 @@
-module Api
-  module V1
-    class RecipesController < ApplicationController
-      def index
-        recipes = Recipe.ordered_by_recent_favorites_and_others
-        render json: recipes
-      end
-    end
+class Api::V1::RecipesController < ApplicationController
+  def index
+    @recipes = Recipe.ordered_by_recent_favorites_and_others
   end
 end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class RecipesController < ApplicationController
+      def index
+        recipes = Recipe.ordered_by_recent_favorites_and_others
+        render json: recipes
+      end
+    end
+  end
+end

--- a/app/models/favorite_recipe.rb
+++ b/app/models/favorite_recipe.rb
@@ -3,4 +3,6 @@ class FavoriteRecipe < ApplicationRecord
   belongs_to :recipe
 
   validates :user_id, uniqueness: { scope: :recipe_id }
+
+  scope :created_in_last_3_days, -> { where(created_at: 3.days.ago..Time.current) }
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -12,4 +12,19 @@ class Recipe < ApplicationRecord
   validates :serving_size, presence: true
   validates :is_draft, inclusion: { in: [true, false] }
   validates :is_public, inclusion: { in: [true, false] }
+
+  scope :popular_in_last_3_days, lambda {
+    joins(:favorite_recipes)
+      .merge(FavoriteRecipe.created_in_last_3_days)
+      .group('recipes.id')
+      .order('COUNT(favorite_recipes.id) DESC')
+  }
+
+  scope :not_favorited_in_last_3_days, lambda {
+    where.not(id: popular_in_last_3_days.pluck(:id))
+  }
+
+  def self.ordered_by_recent_favorites_and_others
+    popular_in_last_3_days + not_favorited_in_last_3_days
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -27,4 +27,6 @@ class Recipe < ApplicationRecord
   def self.ordered_by_recent_favorites_and_others
     popular_in_last_3_days + not_favorited_in_last_3_days
   end
+
+  delegate :count, to: :favoriters, prefix: true
 end

--- a/app/views/api/v1/recipes/index.json.jbuilder
+++ b/app/views/api/v1/recipes/index.json.jbuilder
@@ -1,0 +1,10 @@
+json.array! @recipes do |recipe|
+  json.id recipe.id
+  json.name recipe.name
+  json.description recipe.description
+  json.favorite_count recipe.favoriters_count
+  json.thumbnail recipe.thumbnail
+  json.chef_name recipe.user.name
+  json.created_at recipe.created_at
+  json.updated_at recipe.updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace 'api' do
+  namespace 'api', defaults: { format: 'json' } do
     namespace 'v1' do
       resources :recipes
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace 'api' do
+    namespace 'v1' do
+      resources :recipes
+    end
+  end
 end

--- a/spec/factories/favorite_recipes.rb
+++ b/spec/factories/favorite_recipes.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :favorite_recipe do
+    trait :with_user_and_recipe do
+      after(:build) do |favorite_recipe|
+        favorite_recipe.user = create(:user)
+        favorite_recipe.recipe = create(:recipe, user: create(:user))
+      end
+    end
+  end
+end

--- a/spec/factories/favorite_recipes.rb
+++ b/spec/factories/favorite_recipes.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
         favorite_recipe.recipe = create(:recipe, user: create(:user))
       end
     end
+
+    trait :with_user do
+      user
+    end
   end
 end

--- a/spec/models/favorite_recipe_spec.rb
+++ b/spec/models/favorite_recipe_spec.rb
@@ -9,4 +9,36 @@ RSpec.describe FavoriteRecipe do
 
     it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:recipe_id) }
   end
+
+  describe 'scope' do
+    describe '.created_in_last_3_days' do
+      subject { described_class.created_in_last_3_days }
+
+      context 'レコードが今日作成された場合' do
+        let!(:favorite_recipe_created_today) { create(:favorite_recipe, :with_user_and_recipe) }
+
+        it 'レコードが取得できること' do
+          expect(subject).to eq [favorite_recipe_created_today]
+        end
+      end
+
+      context 'レコードが2日前に作成された場合' do
+        let!(:favorite_recipe_created_2_days_ago) { create(:favorite_recipe, :with_user_and_recipe, created_at: Time.current.ago(2.days)) }
+
+        it 'レコードが取得できること' do
+          expect(subject).to eq [favorite_recipe_created_2_days_ago]
+        end
+      end
+
+      context 'レコードが3日前に作成された場合' do
+        before do
+          create(:favorite_recipe, :with_user_and_recipe, created_at: Time.current.ago(3.days))
+        end
+
+        it 'レコードが取得できないこと' do
+          expect(subject).to eq []
+        end
+      end
+    end
+  end
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.describe Recipe do
+  describe 'scope' do
+    describe '.popular_in_last_3_days' do
+      subject { described_class.popular_in_last_3_days }
+
+      let!(:recipe_gratan) { create(:recipe, :with_user, name: 'グラタン') }
+      let!(:recipe_pasta) { create(:recipe, :with_user, name: 'パスタ') }
+      let!(:recipe_curry) { create(:recipe, :with_user, name: 'カレー') }
+
+      context 'いいねの数に差がある場合' do
+        before do
+          create_list(:favorite_recipe, 5, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(2.days))
+          create_list(:favorite_recipe, 3, :with_user, recipe: recipe_pasta, created_at: Time.current.yesterday)
+          create_list(:favorite_recipe, 2, :with_user, recipe: recipe_curry, created_at: Time.current)
+        end
+
+        it 'いいね数が多い順に取得できること' do
+          expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+        end
+      end
+
+      context 'いいねの数に差がない場合' do
+        before do
+          create(:favorite_recipe, :with_user, recipe: recipe_curry, created_at: Time.current.ago(2.days))
+          create(:favorite_recipe, :with_user, recipe: recipe_pasta, created_at: Time.current.yesterday)
+          create(:favorite_recipe, :with_user, recipe: recipe_gratan, created_at: Time.current)
+        end
+
+        it '作成順に取得できること' do
+          expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+        end
+      end
+
+      context '3日以内にいいねされているレシピがない場合' do
+        before do
+          create(:favorite_recipe, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(3.days))
+          create(:favorite_recipe, :with_user, recipe: recipe_pasta, created_at: Time.current.ago(3.days))
+          create(:favorite_recipe, :with_user, recipe: recipe_curry, created_at: Time.current.ago(3.days))
+        end
+
+        it 'レコードが取得できないこと' do
+          expect(subject).to eq []
+        end
+      end
+    end
+
+    describe '.not_favorited_in_last_3_days' do
+      subject { described_class.not_favorited_in_last_3_days }
+
+      let!(:recipe_gratan) { create(:recipe, :with_user, name: 'グラタン') }
+
+      context '3日以内にいいねされた場合' do
+        before do
+          create(:favorite_recipe, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(2.days))
+        end
+
+        it 'レコードを取得できないこと' do
+          expect(subject).to eq []
+        end
+      end
+
+      context '3日より前にいいねされた場合' do
+        before do
+          create(:favorite_recipe, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(3.days))
+        end
+
+        it 'レコードを取得できること' do
+          expect(subject).to eq [recipe_gratan]
+        end
+      end
+
+      context 'いいねされていない場合' do
+        it 'レコードを取得できること' do
+          expect(subject).to eq [recipe_gratan]
+        end
+      end
+    end
+  end
+
+  describe '#ordered_by_recent_favorites_and_others' do
+    subject { described_class.ordered_by_recent_favorites_and_others }
+
+    let!(:recipe_gratan) { create(:recipe, :with_user, name: 'グラタン') }
+    let!(:recipe_pasta) { create(:recipe, :with_user, name: 'パスタ') }
+    let!(:recipe_curry) { create(:recipe, :with_user, name: 'カレー') }
+
+    context 'すべてのレシピが3日以内にいいねされている場合' do
+      before do
+        create_list(:favorite_recipe, 5, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(2.days))
+        create_list(:favorite_recipe, 3, :with_user, recipe: recipe_pasta, created_at: Time.current.yesterday)
+        create_list(:favorite_recipe, 2, :with_user, recipe: recipe_curry, created_at: Time.current)
+      end
+
+      it 'いいね数が多い順に取得できること' do
+        expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+      end
+    end
+
+    context 'すべてのレシピのいいねが3日よりも前の場合' do
+      before do
+        create_list(:favorite_recipe, 5, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(3.days))
+        create_list(:favorite_recipe, 3, :with_user, recipe: recipe_pasta, created_at: Time.current.ago(4.days))
+        create_list(:favorite_recipe, 2, :with_user, recipe: recipe_curry, created_at: Time.current.ago(5.days))
+      end
+
+      it 'レシピの作成順に取得できること' do
+        expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+      end
+    end
+
+    context 'すべてのレシピがいいねされていない場合' do
+      it 'レシピの作成順に取得できること' do
+        expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+      end
+    end
+
+    context 'すべて混在している場合' do
+      before do
+        create(:favorite_recipe, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(2.days))
+        create_list(:favorite_recipe, 3, :with_user, recipe: recipe_pasta, created_at: Time.current.ago(5.days))
+      end
+
+      it 'すべてのレコードを取得いいね多い順 -> 作成順の優先順に取得できること' do
+        expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
+      end
+    end
+  end
+end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Recipes' do
+  describe 'GET /recipes' do
+    context 'レシピのレコードがあるとき' do
+      let!(:recipe) { create(:recipe, :with_user) }
+
+      it '200を返却すること' do
+        get api_v1_recipes_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'レスポンスの中身は1件のみであること' do
+        get api_v1_recipes_path
+
+        expect(response.parsed_body.length).to eq 1
+      end
+
+      it 'recipeのレコードを返却すること' do
+        get api_v1_recipes_path
+
+        expect(response.parsed_body[0]).to include({ 'id' => recipe.id })
+      end
+    end
+  end
+end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -19,7 +19,16 @@ RSpec.describe 'Recipes' do
       it 'recipeのレコードを返却すること' do
         get api_v1_recipes_path
 
-        expect(response.parsed_body[0]).to include({ 'id' => recipe.id })
+        expect(response.parsed_body[0]).to include({
+                                                     'id' => recipe.id,
+                                                     'name' => recipe.name,
+                                                     'description' => recipe.description,
+                                                     'favorite_count' => recipe.favoriters_count,
+                                                     'thumbnail' => recipe.thumbnail,
+                                                     'chef_name' => recipe.user.name,
+                                                     'created_at' => recipe.created_at.iso8601(3),
+                                                     'updated_at' => recipe.updated_at.iso8601(3)
+                                                   })
       end
     end
   end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
話題のレシピ一覧のGETのエンドポイントを実装しました

## 対象issue
<!-- 例) close #12 -->
close #76 

Notion: https://pollen-echinodon-4ce.notion.site/recipes-12962ed0e4db4e73ad2c80b4ccb6def5

## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ
PRが大きくなりそうだったので、別のIssueで追加対応します。
- 無限スクロール用にページネーション実装
  - https://github.com/qin-team-recipe/01-backend/issues/78

## 参考情報

## 備考
