### PR TITLE
impl: お買い物リスト参照のエンドポイントを実装

### DIFF
--- a/app/controllers/api/v1/cart_lists_controller.rb
+++ b/app/controllers/api/v1/cart_lists_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::CartListsController < ApplicationController
+  before_action :set_user
+
+  def index
+    @cart_lists = @user.cart_lists.preload(:cart_items)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/views/api/v1/cart_lists/index.json.jbuilder
+++ b/app/views/api/v1/cart_lists/index.json.jbuilder
@@ -1,0 +1,16 @@
+json.user_id @cart_lists&.first&.user_id
+
+json.lists @cart_lists do |cart_list|
+  json.id cart_list.id
+  json.recipe_id cart_list.recipe_id
+  json.name cart_list.name
+  json.own_notes cart_list.own_notes
+  json.position cart_list.position
+  json.items cart_list.cart_items do |cart_item|
+    json.name cart_item.name
+    json.is_checked cart_item.is_checked
+    json.position cart_item.position
+    json.created_at cart_item.created_at
+    json.updated_at cart_item.updated_at
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :recipes
 
       resources :users do
-        resources :carts, only: %i[index], controller: 'cart_lists'
+        resources :cart_lists, only: %i[index]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   namespace 'api', defaults: { format: 'json' } do
     namespace 'v1' do
       resources :recipes
+
+      resources :users do
+        resources :carts, only: %i[index], controller: 'cart_lists'
+      end
     end
   end
 end

--- a/spec/factories/cart_items.rb
+++ b/spec/factories/cart_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :cart_item do
+    name { Faker::Name.name }
+    is_checked { false }
+    position { 1 }
+  end
+end

--- a/spec/factories/cart_lists.rb
+++ b/spec/factories/cart_lists.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :cart_list do
+    name { Faker::Name.name }
+    position { 2 } # NOTE: position: 1は初期作成される自分用ノート
+    own_notes { false }
+
+    trait :with_user_and_recipe do
+      after(:build) do |cart_list|
+        # recipeにも関連するuserが設定される
+        cart_list.user = create(:user)
+        cart_list.recipe = create(:recipe, user: cart_list.user)
+      end
+    end
+  end
+end

--- a/spec/requests/cart_lists_spec.rb
+++ b/spec/requests/cart_lists_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'CartLists' do
+  describe 'GET /carts' do
+    context 'レシピのレコードがあるとき' do
+      let!(:cart_list) { create(:cart_list, :with_user_and_recipe) }
+      let!(:cart_item) { create(:cart_item, cart_list:) }
+
+      it '200を返却すること' do
+        get api_v1_user_carts_path(cart_list.user_id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'レスポンスの中身は1件のみであること' do
+        get api_v1_user_carts_path(cart_list.user_id)
+        expect(response.parsed_body['lists'].length).to eq 1
+      end
+
+      it 'listsのレコードを返却すること' do
+        get api_v1_user_carts_path(cart_list.user_id)
+
+        expect(response.parsed_body).to include(
+          'user_id' => cart_list.user_id,
+          'lists' => contain_exactly(
+            hash_including(
+              'id' => cart_list.id,
+              'recipe_id' => cart_list.recipe_id,
+              'name' => cart_list.name,
+              'own_notes' => cart_list.own_notes,
+              'position' => cart_list.position,
+              'items' => contain_exactly(
+                hash_including(
+                  'name' => cart_item.name,
+                  'is_checked' => cart_item.is_checked,
+                  'position' => cart_item.position,
+                  'created_at' => cart_item.created_at.iso8601(3),
+                  'updated_at' => cart_item.updated_at.iso8601(3)
+                )
+              )
+            )
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/cart_lists_spec.rb
+++ b/spec/requests/cart_lists_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe 'CartLists' do
-  describe 'GET /carts' do
+  describe 'GET /cart_lists' do
     context 'レシピのレコードがあるとき' do
       let!(:cart_list) { create(:cart_list, :with_user_and_recipe) }
       let!(:cart_item) { create(:cart_item, cart_list:) }
 
       it '200を返却すること' do
-        get api_v1_user_carts_path(cart_list.user_id)
+        get api_v1_user_cart_lists_path(cart_list.user_id)
         expect(response).to have_http_status(:ok)
       end
 
       it 'レスポンスの中身は1件のみであること' do
-        get api_v1_user_carts_path(cart_list.user_id)
+        get api_v1_user_cart_lists_path(cart_list.user_id)
         expect(response.parsed_body['lists'].length).to eq 1
       end
 
       it 'listsのレコードを返却すること' do
-        get api_v1_user_carts_path(cart_list.user_id)
+        get api_v1_user_cart_lists_path(cart_list.user_id)
 
         expect(response.parsed_body).to include(
           'user_id' => cart_list.user_id,


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- お買い物リスト参照のエンドポイントを実装しました

## 対象issue
<!-- 例) close #12 -->
close #93 
Notion: https://www.notion.so/users-user_id-carts-65754e785e3442acbb83047766d54438

## 重点的に見てほしいところ(不安なところ)
- itemsにだけcreated_atとupdate_atがあるが、これは必要か。あるいはlistsの方にも必要か。
  - 他のエンドポイントにはcreated_atとupdate_atを入れているところが多いので、入れるに倒してもいいかもしれない。
- itemsにidがないが、これは入れた方がいいのではないか。
- ~/cartsではなく/cart_listsというエンドポイントに変えた方がいいか。~

## 後回しにしたところ
- じぶんノートのCartListを初期作成する処理
- Recipeレコードとの関連を持たないじぶんノートを生成するためにすること
  - CartListモデルのbelongs_toにnilを許可すること
  - cart_listsテーブルのrecipe_idカラムにnullを許可すること
  - こちらでやりました
  - https://github.com/qin-team-recipe/01-backend/pull/121
  - https://github.com/qin-team-recipe/01-backend/pull/122

## 参考情報

## 備考
