### PR TITLE
impl:  Userのレコード作成時にCartListのレコードを作成するコールバックを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,6 @@ RSpec/ContextWording:
 
 RSpec/NamedSubject:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,12 @@ Rails/I18nLocaleTexts:
 
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false

--- a/app/models/cart_list.rb
+++ b/app/models/cart_list.rb
@@ -6,5 +6,13 @@ class CartList < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
   validates :position, presence: true, numericality: { only_integer: true }
   validates :own_notes, inclusion: { in: [true, false] }
-  validates :recipe_id, uniqueness: { scope: :user_id }
+  validates :recipe_id, uniqueness: { scope: :user_id }, unless: -> { own_notes }
+
+  validate :ensure_single_own_notes
+
+  private
+
+  def ensure_single_own_notes
+    errors.add(:own_notes, 'じぶんメモはすでに存在します') if CartList.exists?(user_id: user, own_notes: true) && own_notes
+  end
 end

--- a/app/models/cart_list.rb
+++ b/app/models/cart_list.rb
@@ -9,10 +9,19 @@ class CartList < ApplicationRecord
   validates :recipe_id, uniqueness: { scope: :user_id }, unless: -> { own_notes }
 
   validate :ensure_single_own_notes
+  validate :own_notes_values
 
   private
 
   def ensure_single_own_notes
     errors.add(:own_notes, 'じぶんメモはすでに存在します') if CartList.exists?(user_id: user, own_notes: true) && own_notes
+  end
+
+  def own_notes_values
+    return unless own_notes
+
+    errors.add(:name, 'はじぶんメモにしてください') if name != 'じぶんメモ'
+    errors.add(:position, 'は1にしてください') if position != 1
+    errors.add(:recipe_id, 'はじぶんメモに関連づけることはできません') if recipe.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,12 @@ class User < ApplicationRecord
   validates :domain, presence: true, uniqueness: true
   validates :user_type, presence: true, inclusion: { in: ['user', 'chef'] }
   validates :description, length: { maximum: 256 }
+
+  after_create :create_cart_list
+
+  private
+
+  def create_cart_list
+    cart_lists.create(name: 'じぶんメモ', position: 1, own_notes: true)
+  end
 end

--- a/spec/models/cart_list_spec.rb
+++ b/spec/models/cart_list_spec.rb
@@ -37,5 +37,38 @@ RSpec.describe CartList do
         it { is_expected.to be_valid }
       end
     end
+
+    describe '.own_notes_values' do
+      subject { build(:cart_list, user:, recipe:, name:, own_notes:, position:) }
+
+      context 'じぶんメモを作成する場合' do
+        let(:user) { build(:user) }
+        let(:own_notes) { true }
+
+        context 'recipeが紐づいている場合' do
+          let(:recipe) { create(:recipe, user:) }
+          let(:name) { 'じぶんメモ' }
+          let(:position) { 1 }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context 'nameが「じぶんメモ」ではない場合' do
+          let(:recipe) { nil }
+          let(:name) { 'じぶんメモではない' }
+          let(:position) { 1 }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context 'positionが1ではない場合' do
+          let(:recipe) { nil }
+          let(:name) { 'じぶんメモ' }
+          let(:position) { 2 }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
   end
 end

--- a/spec/models/cart_list_spec.rb
+++ b/spec/models/cart_list_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CartList do
+  describe 'validations' do
+    describe '.ensure_single_own_notes' do
+      subject { build(:cart_list, user:, recipe:, name:, own_notes:, position:) }
+
+      context 'じぶんメモが存在している場合' do # userを作成する際にcallbackでじぶんメモを作成している
+        context '新たにじぶんメモを作成する場合' do
+          let(:user) { create(:user) }
+          let(:recipe) { nil }
+          let(:name) { 'じぶんメモ' }
+          let(:own_notes) { true }
+          let(:position) { 1 }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context 'じぶんメモ以外を作成する場合' do
+          let(:user) { create(:user) }
+          let(:recipe) { create(:recipe, user:) }
+          let(:name) { 'デスノート' }
+          let(:own_notes) { false }
+          let(:position) { 2 }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'じぶんメモが存在していない場合' do # userを作成していないことを意味する
+        let(:user) { build(:user) }
+        let(:recipe) { nil }
+        let(:name) { 'じぶんメモ' }
+        let(:own_notes) { true }
+        let(:position) { 1 }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User do
       subject { create(:user) }
 
       it 'CartListのレコードも作成されること' do
-        expect { subject }.to change { CartList.count }.by(1)
+        expect { subject }.to change(CartList, :count).by(1)
       end
 
       it 'CartListのレコードがじぶんメモであること' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,24 @@ RSpec.describe User do
   describe 'validations' do
     it { is_expected.to validate_inclusion_of(:user_type).in_array(['user', 'chef']) }
   end
+
+  describe 'callbacks' do
+    context 'Userのレコードを作成したとき' do
+      subject { create(:user) }
+
+      it 'CartListのレコードも作成されること' do
+        expect { subject }.to change { CartList.count }.by(1)
+      end
+
+      it 'CartListのレコードがじぶんメモであること' do
+        subject
+
+        expect(CartList.last).to have_attributes(
+          name: 'じぶんメモ',
+          position: 1,
+          own_notes: true
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- 初期で用意するじぶんノートを作成するコールバックを実装しました
- じぶんノート単体のバリデーションと、重複しないようにするバリデーションも追加しました

## 対象issue
<!-- 例) close #12 -->
close #93

## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ
CartListのpositionが0のレコードが作れないようにガードする

## 参考情報

## 備考
こちらのPRを前提として実装しています
- https://github.com/qin-team-recipe/01-backend/pull/121