### PR TITLE
fix: じぶんノートのコールバック作成に伴ってspecを修正

### DIFF
--- a/app/views/api/v1/cart_lists/index.json.jbuilder
+++ b/app/views/api/v1/cart_lists/index.json.jbuilder
@@ -1,5 +1,3 @@
-json.user_id @cart_lists&.first&.user_id
-
 json.lists @cart_lists do |cart_list|
   json.id cart_list.id
   json.recipe_id cart_list.recipe_id

--- a/spec/requests/cart_lists_spec.rb
+++ b/spec/requests/cart_lists_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'CartLists' do
   describe 'GET /cart_lists' do
     context 'レシピのレコードがあるとき' do
-      let!(:cart_list) { create(:cart_list, :with_user_and_recipe) }
+      let(:cart_list) { create(:cart_list, :with_user_and_recipe) }
       let!(:cart_item) { create(:cart_item, cart_list:) }
 
       it '200を返却すること' do
@@ -13,7 +13,7 @@ RSpec.describe 'CartLists' do
 
       it 'レスポンスの中身は1件のみであること' do
         get api_v1_user_cart_lists_path(cart_list.user_id)
-        expect(response.parsed_body['lists'].length).to eq 1
+        expect(response.parsed_body['lists'].length).to eq 2
       end
 
       it 'listsのレコードを返却すること' do
@@ -22,6 +22,11 @@ RSpec.describe 'CartLists' do
         expect(response.parsed_body).to include(
           'user_id' => cart_list.user_id,
           'lists' => contain_exactly(
+            hash_including(
+              'name' => 'じぶんメモ',
+              'own_notes' => true,
+              'position' => 1
+            ),
             hash_including(
               'id' => cart_list.id,
               'recipe_id' => cart_list.recipe_id,

--- a/spec/requests/cart_lists_spec.rb
+++ b/spec/requests/cart_lists_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'CartLists' do
         get api_v1_user_cart_lists_path(cart_list.user_id)
 
         expect(response.parsed_body).to include(
-          'user_id' => cart_list.user_id,
           'lists' => contain_exactly(
             hash_including(
               'name' => 'じぶんメモ',


### PR DESCRIPTION
## このプルリクエストで何をしたのか
Userのレコードを作成する際に自動的にじぶんノート（cart_list）を作成するコールバックを設定していましたが、以前に作っていたrequests/cart_lists_spec.rbが対応されていなかったので、修正しました。

ついでと言ってはなんですが、以前のMTGでお話しした「レスポンスにuser_idいらない問題」ですが、こちらもリクエストの時にuser_idは知っているというFEさんからのフィードバックを加味して削除しました。
[不要なuser_idレスポンスを削除](https://github.com/qin-team-recipe/01-backend/pull/130/commits/4f08f483b3c2a5c2dd678f78f8504303916de452)

## 対象issue
## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ

## 参考情報

## 備考
