### PR TITLE
impl: マイレシピ詳細エンドポイントを実装

### DIFF
--- a/app/controllers/api/v1/my_recipes_controller.rb
+++ b/app/controllers/api/v1/my_recipes_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::MyRecipesController < Api::V1::ApplicationBaseController
+  def show
+    @recipe = Recipe.find(params[:id])
+    # TODO: recipe.userとログインユーザーが同じかどうかをチェックする
+    #       recipeのis_publicがfalse かつ recipe.userとログインユーザーが異なる場合、403 Forbiddenの例外を出す
+    #       https://github.com/qin-team-recipe/01-backend/issues/133のIssueで対応する
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -34,12 +34,12 @@ class Recipe < ApplicationRecord
   scope :published, -> { where(is_draft: false, is_public: true) }
   scope :new_arrival_recipes_by_user, ->(user_id) { published.where(user_id:).order(created_at: :desc) }
 
-  def self.ordered_by_recent_favorites_and_others
-    popular_in_last_3_days + not_favorited_in_last_3_days
-  end
-
   delegate :count, to: :favoriters, prefix: true
   delegate :user_type, to: :user
 
   alias author_type user_type
+
+  def self.ordered_by_recent_favorites_and_others
+    popular_in_last_3_days + not_favorited_in_last_3_days
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -42,4 +42,8 @@ class Recipe < ApplicationRecord
   def self.ordered_by_recent_favorites_and_others
     popular_in_last_3_days + not_favorited_in_last_3_days
   end
+
+  def is_favorite?(user)
+    favoriters.exists?(id: user.id)
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -39,4 +39,7 @@ class Recipe < ApplicationRecord
   end
 
   delegate :count, to: :favoriters, prefix: true
+  delegate :user_type, to: :user
+
+  alias author_type user_type
 end

--- a/app/views/api/v1/my_recipes/show.json.jbuilder
+++ b/app/views/api/v1/my_recipes/show.json.jbuilder
@@ -1,0 +1,22 @@
+json.id @recipe.id
+json.name @recipe.name
+json.description @recipe.description
+json.favorite_count @recipe.favoriters_count
+json.thumbnail @recipe.thumbnail
+json.serving_size @recipe.serving_size
+json.is_draft @recipe.is_draft
+json.author_type @recipe.author_type
+json.steps @recipe.steps do |step|
+  json.description step.description
+  json.position step.position
+end
+json.materials @recipe.materials do |material|
+  json.name material.name
+  json.position material.position
+end
+json.external_links @recipe.recipe_external_links do |external_link|
+  json.url external_link.url
+  json.type external_link.url_type
+end
+json.created_at @recipe.created_at
+json.updated_at @recipe.updated_at

--- a/app/views/api/v1/my_recipes/show.json.jbuilder
+++ b/app/views/api/v1/my_recipes/show.json.jbuilder
@@ -4,6 +4,8 @@ json.description @recipe.description
 json.favorite_count @recipe.favoriters_count
 json.thumbnail @recipe.thumbnail
 json.serving_size @recipe.serving_size
+json.is_favorite false # TODO: ログイン機能ができたら実装する
+json.is_public @recipe.is_public
 json.is_draft @recipe.is_draft
 json.author_type @recipe.author_type
 json.steps @recipe.steps do |step|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         member do
           get :popular_recipes, to: 'recipes#user_popular_recipes'
           get :new_arrival_recipes, to: 'recipes#user_new_arrival_recipes'
+          get '/recipes/:id', to: 'my_recipes#show', as: :my_recipes_show
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,11 @@ Rails.application.routes.draw do
 
       resources :users do
         resources :cart_lists, only: %i[index]
+        resources :my_recipes, only: %i[show]
 
         member do
           get :popular_recipes, to: 'recipes#user_popular_recipes'
           get :new_arrival_recipes, to: 'recipes#user_new_arrival_recipes'
-          get '/recipes/:id', to: 'my_recipes#show', as: :my_recipes_show
         end
       end
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Recipe do
     context 'レシピにお気に入りがついていない場合' do
       let(:user) { create(:user) }
 
-      it 'trueが返却されること' do
+      it 'falseが返却されること' do
         expect(subject).to be false
       end
     end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -210,14 +210,14 @@ RSpec.describe Recipe do
     let!(:recipe) { create(:recipe, :with_user) }
 
     context 'レシピにお気に入りがついている場合' do
-      let!(:favorted_user) { create(:user) }
+      let!(:favorited_user) { create(:user) }
 
       before do
-        create(:favorite_recipe, user: favorted_user, recipe:)
+        create(:favorite_recipe, user: favorited_user, recipe:)
       end
 
       context '引数のuserとレシピをお気に入りにしているユーザーが同じ場合' do
-        let(:user) { favorted_user }
+        let(:user) { favorited_user }
 
         it 'trueが返却されること' do
           expect(subject).to be true

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -203,4 +203,42 @@ RSpec.describe Recipe do
       end
     end
   end
+
+  describe '#is_favorite?' do
+    subject { recipe.is_favorite?(user) }
+
+    let!(:recipe) { create(:recipe, :with_user) }
+
+    context 'レシピにお気に入りがついている場合' do
+      let!(:favorted_user) { create(:user) }
+
+      before do
+        create(:favorite_recipe, user: favorted_user, recipe:)
+      end
+
+      context '引数のuserとレシピをお気に入りにしているユーザーが同じ場合' do
+        let(:user) { favorted_user }
+
+        it 'trueが返却されること' do
+          expect(subject).to be true
+        end
+      end
+
+      context '引数のuserとレシピをお気に入りにしているユーザーが異なる場合' do
+        let(:user) { create(:user) }
+
+        it 'falseが返却されること' do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context 'レシピにお気に入りがついていない場合' do
+      let(:user) { create(:user) }
+
+      it 'trueが返却されること' do
+        expect(subject).to be false
+      end
+    end
+  end
 end

--- a/spec/requests/my_recipes_spec.rb
+++ b/spec/requests/my_recipes_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'MyRecipes' do
+  describe 'GET /recipes/:id' do
+    context 'レシピのレコードがあるとき' do
+      let!(:recipe) { create(:recipe, :with_user) }
+      let!(:step) { create(:step, recipe:) }
+      let!(:material) { create(:material, recipe:) }
+      let!(:recipe_external_link) { create(:recipe_external_link, :with_url_type, recipe:) }
+
+      it '200を返却すること' do
+        get my_recipes_show_api_v1_user_path(recipe)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'recipeのレコードを返却すること' do
+        get my_recipes_show_api_v1_user_path(recipe)
+
+        expect(response.parsed_body).to include({
+                                                  'id' => recipe.id,
+                                                  'name' => recipe.name,
+                                                  'description' => recipe.description,
+                                                  'favorite_count' => recipe.favoriters_count,
+                                                  'thumbnail' => recipe.thumbnail,
+                                                  'serving_size' => recipe.serving_size,
+                                                  'is_draft' => recipe.is_draft,
+                                                  'author_type' => recipe.author_type,
+                                                  'steps' => [
+                                                    'description' => step.description,
+                                                    'position' => step.position
+                                                  ],
+                                                  'materials' => [
+                                                    'name' => material.name,
+                                                    'position' => material.position
+                                                  ],
+                                                  'external_links' => [
+                                                    'type' => recipe_external_link.url_type,
+                                                    'url' => recipe_external_link.url
+                                                  ],
+                                                  'created_at' => recipe.created_at.iso8601(3),
+                                                  'updated_at' => recipe.updated_at.iso8601(3)
+                                                })
+      end
+    end
+  end
+end

--- a/spec/requests/my_recipes_spec.rb
+++ b/spec/requests/my_recipes_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'MyRecipes' do
                                                   'favorite_count' => recipe.favoriters_count,
                                                   'thumbnail' => recipe.thumbnail,
                                                   'serving_size' => recipe.serving_size,
+                                                  'is_favorite' => false, # TODO: ログイン機能ができたら実装する
+                                                  'is_public' => recipe.is_public,
                                                   'is_draft' => recipe.is_draft,
                                                   'author_type' => recipe.author_type,
                                                   'steps' => [

--- a/spec/requests/my_recipes_spec.rb
+++ b/spec/requests/my_recipes_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe 'MyRecipes' do
       let!(:recipe_external_link) { create(:recipe_external_link, :with_url_type, recipe:) }
 
       it '200を返却すること' do
-        get my_recipes_show_api_v1_user_path(recipe)
+        get api_v1_user_my_recipe_path(recipe.user, recipe)
         expect(response).to have_http_status(:ok)
       end
 
       it 'recipeのレコードを返却すること' do
-        get my_recipes_show_api_v1_user_path(recipe)
+        get api_v1_user_my_recipe_path(recipe.user, recipe)
 
         expect(response.parsed_body).to include({
                                                   'id' => recipe.id,


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- SSIA

## 対象issue
<!-- 例) close #12 -->
close #116 
Notion: https://www.notion.so/users-user_id-recipes-recipe_id-63142b16b0aa4add8d805b9ce66bacac

## 重点的に見てほしいところ(不安なところ)
- my_recipes_controllerを作っていますが、これで良いですか？
  - controllerの粒度が私の中でもふわっとしていますが、マイレシピ関連はCRUDが一通りあるので、recipes_controllerの中にあると大きくなりすぎるかな、と思い分けてみました。

## 後回しにしたところ
- 非公開中にレシピ作成者にしか見えない実装
  - ログイン機能ができた後の対応になるので、Issueを切りました
  - https://github.com/qin-team-recipe/01-backend/issues/133

## 参考情報

## 備考
