### PR TITLE
modify: chefs_controllerのクラス継承を`Api::V1::ApplicationBaseController`に変更

### DIFF
--- a/app/controllers/api/v1/chefs_controller.rb
+++ b/app/controllers/api/v1/chefs_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ChefsController < ApplicationController
+class Api::V1::ChefsController < Api::V1::ApplicationBaseController
   def index
     @chefs = User.by_type_chef
   end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- API用のクラスを継承するようにしました。
- これはchefs_controller実装の裏での変更だったので、このコントローラのみ変更がされていない背景がありました。そのため、このタイミングでの変更をしました。
- 400や500などのエラーハンドリングがされるようになります。
- 今後実装するAPI関連のコントローラはこ`Api::V1::ApplicationBaseController`を継承してください。

## 対象issue


## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ

## 参考情報

## 備考
