### PR TITLE
fix: 話題のレシピ/人気レシピ/新着レシピのロジックを変更

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -15,8 +15,11 @@ class Api::V1::RecipesController < Api::V1::ApplicationBaseController
     # @user_popular_recipes = Recipe.without_draft.popular_recipes_by_user(params[:id])
   end
 
+  # NOTE: 新着レシピ一覧
   def user_new_arrival_recipes
-    @user_new_arrival_recipes = Recipe.new_arrival_recipes_by_user(params[:id])
+    @user_new_arrival_recipes = Recipe.published.new_arrival_recipes_by_user(params[:id]) # params[:id] -> user_id
+    # TODO: ログイン機能が実装されたら、current_userとrecipeのuser_idが同じ場合は以下のようにする
+    # @user_new_arrival_recipes = Recipe.without_draft.new_arrival_recipes_by_user(params[:id])
   end
 
   private

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -8,8 +8,11 @@ class Api::V1::RecipesController < Api::V1::ApplicationBaseController
     @recipe = Recipe.find(params[:id])
   end
 
+  # NOTE: 人気レシピ一覧
   def user_popular_recipes
-    @user_popular_recipes = Recipe.popular_recipes_by_user(params[:id]) # params[:id] -> user_id
+    @user_popular_recipes = Recipe.published.popular_recipes_by_user(params[:id]) # params[:id] -> user_id
+    # TODO: ログイン機能が実装されたら、current_userとrecipeのuser_idが同じ場合は以下のようにする
+    # @user_popular_recipes = Recipe.without_draft.popular_recipes_by_user(params[:id])
   end
 
   def user_new_arrival_recipes

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::RecipesController < Api::V1::ApplicationBaseController
   # NOTE: 話題のレシピ一覧
   def index
-    @recipes = Recipe.published.ordered_by_recent_favorites_and_others
+    @recipes = Recipe.by_chef.published.ordered_by_recent_favorites_and_others
   end
 
   def show

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::RecipesController < Api::V1::ApplicationBaseController
+  # NOTE: 話題のレシピ一覧
   def index
-    @recipes = Recipe.ordered_by_recent_favorites_and_others
+    @recipes = Recipe.published.ordered_by_recent_favorites_and_others
   end
 
   def show

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -28,6 +28,7 @@ class Recipe < ApplicationRecord
 
   scope :popular_recipes_by_user, lambda { |user_id|
     left_joins(:favorite_recipes)
+      .published
       .where(user_id:)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -23,7 +23,7 @@ class Recipe < ApplicationRecord
 
   scope :not_favorited_in_last_3_days, lambda {
     published
-    .where.not(id: popular_in_last_3_days.pluck(:id))
+      .where.not(id: popular_in_last_3_days.pluck(:id))
   }
 
   scope :popular_recipes_by_user, lambda { |user_id|
@@ -35,7 +35,10 @@ class Recipe < ApplicationRecord
   }
 
   scope :published, -> { where(is_draft: false, is_public: true) }
-  scope :new_arrival_recipes_by_user, ->(user_id) { published.where(user_id:).order(created_at: :desc) }
+  scope :with_draft, -> { where(is_draft: true) }
+  scope :without_draft, -> { where(is_draft: false) }
+
+  scope :new_arrival_recipes_by_user, ->(user_id) { without_draft.where(user_id:).order(created_at: :desc) }
 
   delegate :count, to: :favoriters, prefix: true
   delegate :user_type, to: :user

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -42,8 +42,8 @@ class Recipe < ApplicationRecord
   # NOTE: 引数のユーザーが作成したレシピを新着順に並べる
   scope :new_arrival_recipes_by_user, lambda { |user_id|
     without_draft # NOTE: 下書き以外のレシピを返却する
-    .where(user_id:)
-    .order(created_at: :desc)
+      .where(user_id:)
+      .order(created_at: :desc)
   }
 
   delegate :count, to: :favoriters, prefix: true

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -13,6 +13,10 @@ class Recipe < ApplicationRecord
   validates :is_draft, inclusion: { in: [true, false] }
   validates :is_public, inclusion: { in: [true, false] }
 
+  scope :published, -> { where(is_draft: false, is_public: true) }
+  scope :with_draft, -> { where(is_draft: true) }
+  scope :without_draft, -> { where(is_draft: false) }
+
   scope :popular_in_last_3_days, lambda {
     joins(:favorite_recipes)
       .published
@@ -34,11 +38,11 @@ class Recipe < ApplicationRecord
       .order('COUNT(favorite_recipes.id) DESC')
   }
 
-  scope :published, -> { where(is_draft: false, is_public: true) }
-  scope :with_draft, -> { where(is_draft: true) }
-  scope :without_draft, -> { where(is_draft: false) }
-
-  scope :new_arrival_recipes_by_user, ->(user_id) { without_draft.where(user_id:).order(created_at: :desc) }
+  scope :new_arrival_recipes_by_user, lambda { |user_id|
+    without_draft
+    .where(user_id:)
+    .order(created_at: :desc)
+  }
 
   delegate :count, to: :favoriters, prefix: true
   delegate :user_type, to: :user

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -15,6 +15,7 @@ class Recipe < ApplicationRecord
 
   scope :popular_in_last_3_days, lambda {
     joins(:favorite_recipes)
+      .published
       .merge(FavoriteRecipe.created_in_last_3_days)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -19,21 +19,18 @@ class Recipe < ApplicationRecord
 
   scope :popular_in_last_3_days, lambda {
     joins(:favorite_recipes)
-      .published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
       .merge(FavoriteRecipe.created_in_last_3_days)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')
   }
 
   scope :not_favorited_in_last_3_days, lambda {
-    published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
-      .where.not(id: popular_in_last_3_days.pluck(:id))
+    where.not(id: popular_in_last_3_days.pluck(:id))
   }
 
   # NOTE: 引数のユーザーが作成したレシピを人気順に並べる
   scope :popular_recipes_by_user, lambda { |user_id|
     left_joins(:favorite_recipes)
-      .published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
       .where(user_id:)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')
@@ -41,9 +38,7 @@ class Recipe < ApplicationRecord
 
   # NOTE: 引数のユーザーが作成したレシピを新着順に並べる
   scope :new_arrival_recipes_by_user, lambda { |user_id|
-    without_draft # NOTE: 下書き以外のレシピを返却する
-      .where(user_id:)
-      .order(created_at: :desc)
+    where(user_id:).order(created_at: :desc)
   }
 
   delegate :count, to: :favoriters, prefix: true

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -19,27 +19,29 @@ class Recipe < ApplicationRecord
 
   scope :popular_in_last_3_days, lambda {
     joins(:favorite_recipes)
-      .published
+      .published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
       .merge(FavoriteRecipe.created_in_last_3_days)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')
   }
 
   scope :not_favorited_in_last_3_days, lambda {
-    published
+    published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
       .where.not(id: popular_in_last_3_days.pluck(:id))
   }
 
+  # NOTE: 引数のユーザーが作成したレシピを人気順に並べる
   scope :popular_recipes_by_user, lambda { |user_id|
     left_joins(:favorite_recipes)
-      .published
+      .published # NOTE: 人気関連のロジックは公開中のレシピのレコードで行う
       .where(user_id:)
       .group('recipes.id')
       .order('COUNT(favorite_recipes.id) DESC')
   }
 
+  # NOTE: 引数のユーザーが作成したレシピを新着順に並べる
   scope :new_arrival_recipes_by_user, lambda { |user_id|
-    without_draft
+    without_draft # NOTE: 下書き以外のレシピを返却する
     .where(user_id:)
     .order(created_at: :desc)
   }

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -41,6 +41,10 @@ class Recipe < ApplicationRecord
     where(user_id:).order(created_at: :desc)
   }
 
+  scope :by_chef, lambda {
+    joins(:user).where(users: { user_type: 'chef' })
+  }
+
   delegate :count, to: :favoriters, prefix: true
   delegate :user_type, to: :user
 

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -22,7 +22,8 @@ class Recipe < ApplicationRecord
   }
 
   scope :not_favorited_in_last_3_days, lambda {
-    where.not(id: popular_in_last_3_days.pluck(:id))
+    published
+    .where.not(id: popular_in_last_3_days.pluck(:id))
   }
 
   scope :popular_recipes_by_user, lambda { |user_id|

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -8,7 +8,17 @@ FactoryBot.define do
   end
 
   trait :with_user do
-    user
+    before(:create) do |recipe|
+      user = create(:user, user_type: 'user')
+      recipe.user = user
+    end
+  end
+
+  trait :with_chef do
+    before(:create) do |recipe|
+      user = create(:user, user_type: 'chef')
+      recipe.user = user
+    end
   end
 
   trait :with_step do

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -131,6 +131,23 @@ RSpec.describe Recipe do
         end
       end
     end
+
+    describe '.by_chef' do
+      subject { described_class.by_chef }
+
+      context 'chefとuserが作成したレシピが混在している場合' do
+        let!(:recipe_gratan) { create(:recipe, :with_chef, name: 'グラタン') }
+        let!(:recipe_pasta) { create(:recipe, :with_chef, name: 'パスタ') }
+
+        before do
+          create(:recipe, :with_user, name: 'カレー')
+        end
+
+        it 'chefのレシピのみ取得できること' do
+          expect(subject).to eq [recipe_gratan, recipe_pasta]
+        end
+      end
+    end
   end
 
   describe '.new_arrival_recipes_by_user' do

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe Recipe do
           expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
         end
       end
+
+      context '非公開のレシピがある場合' do
+        let!(:recipe_not_public) { create(:recipe, :with_user, is_public: false) }
+
+        it '非公開のレシピが取得されないこと' do
+          expect(subject).not_to include(recipe_not_public)
+        end
+      end
     end
   end
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -44,17 +44,6 @@ RSpec.describe Recipe do
           expect(subject).to eq []
         end
       end
-
-      context 'いいねさされたレシピが非公開の場合' do
-        before do
-          recipe_not_public = create(:recipe, :with_user, is_public: false)
-          create_list(:favorite_recipe, 5, :with_user, recipe: recipe_not_public, created_at: Time.current)
-        end
-
-        it 'レコードが取得できないこと' do
-          expect(subject).to eq []
-        end
-      end
     end
 
     describe '.not_favorited_in_last_3_days' do
@@ -85,14 +74,6 @@ RSpec.describe Recipe do
       context 'いいねされていない場合' do
         it 'レコードを取得できること' do
           expect(subject).to eq [recipe_gratan]
-        end
-      end
-
-      context '非公開のレシピがある場合' do
-        let!(:recipe_not_public) { create(:recipe, :with_user, is_public: false) }
-
-        it '非公開のレシピが取得されないこと' do
-          expect(subject).not_to include(recipe_not_public)
         end
       end
     end
@@ -149,14 +130,6 @@ RSpec.describe Recipe do
           expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
         end
       end
-
-      context '非公開のレシピがある場合' do
-        let!(:recipe_not_public) { create(:recipe, :with_user, is_public: false) }
-
-        it '非公開のレシピが取得されないこと' do
-          expect(subject).not_to include(recipe_not_public)
-        end
-      end
     end
   end
 
@@ -177,11 +150,6 @@ RSpec.describe Recipe do
 
     it '他のユーザーのレシピが取得されないこと' do
       expect(subject).not_to include(another_user_recipe)
-    end
-
-    it '下書きレシピが取得されないこと' do
-      draft_recipe = create(:recipe, user:, is_draft: true)
-      expect(subject).not_to include(draft_recipe)
     end
   end
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -102,13 +102,13 @@ RSpec.describe Recipe do
 
       let(:user) { create(:user) }
 
-      let!(:recipe_gratan) { create(:recipe, user:, name: 'グラタン') }
-      let!(:recipe_pasta) { create(:recipe, user:, name: 'パスタ') }
-      let!(:recipe_curry) { create(:recipe, user:, name: 'カレー') }
-
-      let!(:another_user_recipe) { create(:recipe, :with_user, name: 'おにぎり') }
-
       context 'いいねの数に差がある場合' do
+        let!(:recipe_gratan) { create(:recipe, user:, name: 'グラタン') }
+        let!(:recipe_pasta) { create(:recipe, user:, name: 'パスタ') }
+        let!(:recipe_curry) { create(:recipe, user:, name: 'カレー') }
+
+        let!(:another_user_recipe) { create(:recipe, :with_user, name: 'おにぎり') }
+
         before do
           create_list(:favorite_recipe, 5, :with_user, recipe: recipe_gratan, created_at: Time.current.ago(2.days))
           create_list(:favorite_recipe, 3, :with_user, recipe: recipe_pasta, created_at: Time.current.yesterday)
@@ -125,6 +125,10 @@ RSpec.describe Recipe do
       end
 
       context 'いいねの数に差がない場合' do
+        let!(:recipe_gratan) { create(:recipe, user:, name: 'グラタン') }
+        let!(:recipe_pasta) { create(:recipe, user:, name: 'パスタ') }
+        let!(:recipe_curry) { create(:recipe, user:, name: 'カレー') }
+
         before do
           create(:favorite_recipe, :with_user, recipe: recipe_curry, created_at: Time.current.ago(2.days))
           create(:favorite_recipe, :with_user, recipe: recipe_pasta, created_at: Time.current.yesterday)
@@ -137,6 +141,10 @@ RSpec.describe Recipe do
       end
 
       context 'いいねされているレシピがない場合' do
+        let!(:recipe_gratan) { create(:recipe, user:, name: 'グラタン') }
+        let!(:recipe_pasta) { create(:recipe, user:, name: 'パスタ') }
+        let!(:recipe_curry) { create(:recipe, user:, name: 'カレー') }
+
         it '作成順に取得できること' do
           expect(subject).to eq [recipe_gratan, recipe_pasta, recipe_curry]
         end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe Recipe do
           expect(subject).to eq [recipe_gratan]
         end
       end
+
+      context '非公開のレシピがある場合' do
+        let!(:recipe_not_public) { create(:recipe, :with_user, is_public: false) }
+
+        it '非公開のレシピが取得されないこと' do
+          expect(subject).not_to include(recipe_not_public)
+        end
+      end
     end
 
     describe '.popular_recipes_by_user' do

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Recipe do
 
       context 'いいねさされたレシピが非公開の場合' do
         before do
-          recipe_not_public= create(:recipe, :with_user, is_public: false)
+          recipe_not_public = create(:recipe, :with_user, is_public: false)
           create_list(:favorite_recipe, 5, :with_user, recipe: recipe_not_public, created_at: Time.current)
         end
 
@@ -174,11 +174,6 @@ RSpec.describe Recipe do
     it '下書きレシピが取得されないこと' do
       draft_recipe = create(:recipe, user:, is_draft: true)
       expect(subject).not_to include(draft_recipe)
-    end
-
-    it '非公開レシピが取得されないこと' do
-      not_public_recipe = create(:recipe, user:, is_public: false)
-      expect(subject).not_to include(not_public_recipe)
     end
   end
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe Recipe do
           expect(subject).to eq []
         end
       end
+
+      context 'いいねさされたレシピが非公開の場合' do
+        before do
+          recipe_not_public= create(:recipe, :with_user, is_public: false)
+          create_list(:favorite_recipe, 5, :with_user, recipe: recipe_not_public, created_at: Time.current)
+        end
+
+        it 'レコードが取得できないこと' do
+          expect(subject).to eq []
+        end
+      end
     end
 
     describe '.not_favorited_in_last_3_days' do

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -148,6 +148,55 @@ RSpec.describe 'Recipes' do
     end
   end
 
+  describe 'GET /users/:user_id/new_arrival_recipes' do
+    let(:user) { create(:user) }
+
+    context 'レシピのレコードがあるとき' do
+      context 'レシピが公開中の場合' do
+        let!(:recipe) { create(:recipe, user:, is_public: true) }
+
+        it '200を返却すること' do
+          get new_arrival_recipes_api_v1_user_path(user)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'レスポンスの中身は1件のみであること' do
+          get new_arrival_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body.length).to eq 1
+        end
+
+        it 'recipeのレコードを返却すること' do
+          get new_arrival_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body[0]).to include({
+                                                       'id' => recipe.id,
+                                                       'name' => recipe.name,
+                                                       'description' => recipe.description,
+                                                       'favorite_count' => recipe.favoriters_count,
+                                                       'thumbnail' => recipe.thumbnail,
+                                                       'chef_name' => recipe.user.name,
+                                                       'created_at' => recipe.created_at.iso8601(3),
+                                                       'updated_at' => recipe.updated_at.iso8601(3)
+                                                     })
+        end
+      end
+
+      context 'レシピが非公開中の場合' do
+        before do
+          create(:recipe, :with_user, is_public: false)
+        end
+
+        it '200を返却すること' do
+          get new_arrival_recipes_api_v1_user_path(user)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'レスポンスの中身は0件であること' do
+          get new_arrival_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body.length).to eq 0
+        end
       end
     end
   end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -4,38 +4,57 @@ RSpec.describe 'Recipes' do
   describe 'GET /recipes' do
     context 'レシピのレコードがあるとき' do
       context 'レシピが公開中の場合' do
-        let!(:recipe) { create(:recipe, :with_user, is_public: true) }
+        let!(:recipe) { create(:recipe, user:, is_public: true) }
 
-        it '200を返却すること' do
-          get api_v1_recipes_path
-          expect(response).to have_http_status(:ok)
+        context '有名シェフが作成したレシピの場合' do
+          let(:user) { create(:user, user_type: 'chef') }
+
+          it '200を返却すること' do
+            get api_v1_recipes_path
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'レスポンスの中身は1件のみであること' do
+            get api_v1_recipes_path
+
+            expect(response.parsed_body.length).to eq 1
+          end
+
+          it 'recipeのレコードを返却すること' do
+            get api_v1_recipes_path
+
+            expect(response.parsed_body[0]).to include({
+                                                         'id' => recipe.id,
+                                                         'name' => recipe.name,
+                                                         'description' => recipe.description,
+                                                         'favorite_count' => recipe.favoriters_count,
+                                                         'thumbnail' => recipe.thumbnail,
+                                                         'chef_name' => recipe.user.name,
+                                                         'created_at' => recipe.created_at.iso8601(3),
+                                                         'updated_at' => recipe.updated_at.iso8601(3)
+                                                       })
+          end
         end
 
-        it 'レスポンスの中身は1件のみであること' do
-          get api_v1_recipes_path
+        context '一般シェフが作成したレシピの場合' do
+          let(:user) { create(:user, user_type: 'user') }
 
-          expect(response.parsed_body.length).to eq 1
-        end
+          it '200を返却すること' do
+            get api_v1_recipes_path
+            expect(response).to have_http_status(:ok)
+          end
 
-        it 'recipeのレコードを返却すること' do
-          get api_v1_recipes_path
+          it 'レスポンスの中身は0件であること' do
+            get api_v1_recipes_path
 
-          expect(response.parsed_body[0]).to include({
-                                                       'id' => recipe.id,
-                                                       'name' => recipe.name,
-                                                       'description' => recipe.description,
-                                                       'favorite_count' => recipe.favoriters_count,
-                                                       'thumbnail' => recipe.thumbnail,
-                                                       'chef_name' => recipe.user.name,
-                                                       'created_at' => recipe.created_at.iso8601(3),
-                                                       'updated_at' => recipe.updated_at.iso8601(3)
-                                                     })
+            expect(response.parsed_body.length).to eq 0
+          end
         end
       end
 
       context 'レシピが非公開中の場合' do
         before do
-          create(:recipe, :with_user, is_public: false)
+          create(:recipe, :with_chef, is_public: false)
         end
 
         it '200を返却すること' do
@@ -54,7 +73,7 @@ RSpec.describe 'Recipes' do
 
   describe 'GET /recipes/:id' do
     context 'レシピのレコードがあるとき' do
-      let!(:recipe) { create(:recipe, :with_user) }
+      let!(:recipe) { create(:recipe, :with_chef) }
       let!(:step) { create(:step, recipe:) }
       let!(:material) { create(:material, recipe:) }
       let!(:recipe_external_link) { create(:recipe_external_link, :with_url_type, recipe:) }

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -97,33 +97,57 @@ RSpec.describe 'Recipes' do
 
   describe 'GET /users/:user_id/popular_recipes' do
     let(:user) { create(:user) }
-    let!(:recipe) { create(:recipe, user:) }
 
     context 'レシピのレコードがあるとき' do
-      it '200を返却すること' do
-        get popular_recipes_api_v1_user_path(user)
-        expect(response).to have_http_status(:ok)
+      context 'レシピが公開中の場合' do
+        let!(:recipe) { create(:recipe, user:, is_public: true) }
+
+        it '200を返却すること' do
+          get popular_recipes_api_v1_user_path(user)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'レスポンスの中身は1件のみであること' do
+          get popular_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body.length).to eq 1
+        end
+
+        it 'recipeのレコードを返却すること' do
+          get popular_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body[0]).to include({
+                                                       'id' => recipe.id,
+                                                       'name' => recipe.name,
+                                                       'description' => recipe.description,
+                                                       'favorite_count' => recipe.favoriters_count,
+                                                       'thumbnail' => recipe.thumbnail,
+                                                       'chef_name' => recipe.user.name,
+                                                       'created_at' => recipe.created_at.iso8601(3),
+                                                       'updated_at' => recipe.updated_at.iso8601(3)
+                                                     })
+        end
       end
 
-      it 'レスポンスの中身は1件のみであること' do
-        get popular_recipes_api_v1_user_path(user)
+      context 'レシピが非公開中の場合' do
+        before do
+          create(:recipe, :with_user, is_public: false)
+        end
 
-        expect(response.parsed_body.length).to eq 1
+        it '200を返却すること' do
+          get popular_recipes_api_v1_user_path(user)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'レスポンスの中身は0件であること' do
+          get popular_recipes_api_v1_user_path(user)
+
+          expect(response.parsed_body.length).to eq 0
+        end
       end
+    end
+  end
 
-      it 'recipeのレコードを返却すること' do
-        get popular_recipes_api_v1_user_path(user)
-
-        expect(response.parsed_body[0]).to include({
-                                                     'id' => recipe.id,
-                                                     'name' => recipe.name,
-                                                     'description' => recipe.description,
-                                                     'favorite_count' => recipe.favoriters_count,
-                                                     'thumbnail' => recipe.thumbnail,
-                                                     'chef_name' => recipe.user.name,
-                                                     'created_at' => recipe.created_at.iso8601(3),
-                                                     'updated_at' => recipe.updated_at.iso8601(3)
-                                                   })
       end
     end
   end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- 話題のレシピ/人気レシピ/新着レシピのロジックを変更しました。

1. シェフ詳細ページ
  - user_type = chef
  - 非公開は含まない
  - 下書きは含まない

2. 一般シェフ詳細ページ
  - user_type = user
  - 非公開は含まない
  - 下書きは含まない

3. マイページ
  - user_type = user
  - 非公開を含む
  - 下書きは含まない

## 対象issue
<!-- 例) close #12 -->
close #

## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ

## 参考情報
以下の結論をもとに修正しました
https://github.com/qin-team-recipe/01-backend/pull/136#discussion_r1320705482

## 備考
