### PR TITLE
レシピ検索のエンドポイントの実装

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -22,6 +22,13 @@ class Api::V1::RecipesController < Api::V1::ApplicationBaseController
     # @user_new_arrival_recipes = Recipe.without_draft.new_arrival_recipes_by_user(params[:id])
   end
 
+  def search
+    keyword = params[:keyword]
+    page = params[:page].to_i.zero? ? 1 : params[:page].to_i
+    render(json: { error: '不正なパラメータです。' }, status: :unprocessable_entity) if keyword.nil?
+    @recipes = Recipe.by_chef.published.ordered_by_recent_favorites_and_others_relation.search_by_name(keyword).paginate(page)
+  end
+
   private
 
   def recipe_params

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::RecipesController < Api::V1::ApplicationBaseController
     keyword = params[:keyword]
     page = params[:page].to_i.zero? ? 1 : params[:page].to_i
     render(json: { error: '不正なパラメータです。' }, status: :unprocessable_entity) if keyword.nil?
-    @recipes = Recipe.by_chef.published.ordered_by_recent_favorites_and_others_relation.search_by_name(keyword).paginate(page)
+    @recipes = Recipe.by_chef.published.ordered_by_recent_favorites_and_others.search_by_name(keyword).paginate(page)
   end
 
   private

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -24,8 +24,10 @@ class Api::V1::RecipesController < Api::V1::ApplicationBaseController
 
   def search
     keyword = params[:keyword]
+
+    raise ActionController::ParameterMissing, 'keyword parameter is missing' if keyword.nil?
+
     page = params[:page].to_i.zero? ? 1 : params[:page].to_i
-    render(json: { error: '不正なパラメータです。' }, status: :unprocessable_entity) if keyword.nil?
     @recipes = Recipe.by_chef.published.ordered_by_recent_favorites_and_others.search_by_name(keyword).paginate(page)
   end
 

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -57,10 +57,6 @@ class Recipe < ApplicationRecord
   alias author_type user_type
 
   def self.ordered_by_recent_favorites_and_others
-    popular_in_last_3_days + not_favorited_in_last_3_days
-  end
-
-  def self.ordered_by_recent_favorites_and_others_relation
     where(id: popular_in_last_3_days.pluck(:id) + not_favorited_in_last_3_days.pluck(:id))
   end
 

--- a/app/views/api/v1/recipes/search.json.jbuilder
+++ b/app/views/api/v1/recipes/search.json.jbuilder
@@ -1,0 +1,10 @@
+json.array! @recipes do |recipe|
+  json.id recipe.id
+  json.name recipe.name
+  json.description recipe.description
+  json.favorite_count recipe.favoriters_count
+  json.thumbnail recipe.thumbnail
+  json.chef_name recipe.user.name
+  json.created_at recipe.created_at
+  json.updated_at recipe.updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   namespace 'api', defaults: { format: 'json' } do
     namespace 'v1' do
-      resources :recipes, only: %i[index show]
+      resources :recipes, only: %i[index show] do
+        collection do
+          get :search
+        end
+      end
 
       resources :users do
         resources :cart_lists, only: %i[index]

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe 'Recipes' do
         get '/api/v1/recipes/search', params: { keyword: 'グラタン', page: 1 }
       end
 
-      it 'chefタイプのユーザー以外のレシピは含まれないこと' do
+      it '一般シェフユーザーのレシピは含まれないこと' do
         expect(response.parsed_body).to eq([])
       end
     end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -275,12 +275,8 @@ RSpec.describe 'Recipes' do
           get '/api/v1/recipes/search', params: { page: 1 }
         end
 
-        it '422 Unprocessable Entityを返却すること' do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-
-        it '適切なエラーメッセージを返却すること' do
-          expect(response.parsed_body).to include('error' => '不正なパラメータです。')
+        it '400 Bad Requestを返却すること' do
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -219,4 +219,138 @@ RSpec.describe 'Recipes' do
       end
     end
   end
+
+  describe 'GET /api/v1/recipes/search' do
+    let(:user) { create(:user, user_type: 'chef') }
+
+    context 'レシピのレコードがあるとき' do
+      let!(:recipe) { create(:recipe, user:, name: 'パスタグラタン') }
+
+      before do
+        get '/api/v1/recipes/search', params: { keyword: 'グラタン', page: 1 }
+      end
+
+      it '200を返却すること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'レスポンスの中身は1件のみであること' do
+        expect(response.parsed_body.length).to eq 1
+      end
+
+      it 'recipeのレコードを返却すること' do
+        expect(response.parsed_body[0]).to include({
+                                                     'id' => recipe.id,
+                                                     'name' => recipe.name,
+                                                     'description' => recipe.description,
+                                                     'favorite_count' => recipe.favoriters_count,
+                                                     'thumbnail' => recipe.thumbnail,
+                                                     'chef_name' => recipe.user.name,
+                                                     'created_at' => recipe.created_at.iso8601(3),
+                                                     'updated_at' => recipe.updated_at.iso8601(3)
+                                                   })
+      end
+    end
+
+    context 'キーワードが与えられていない時' do
+      context 'キーワードが空の文字列の時' do
+        before do
+          create(:recipe, user:, name: 'パスタ')
+          create(:recipe, user:, name: 'カレー')
+          create(:recipe, user:, name: 'ハンバーグ')
+          get '/api/v1/recipes/search', params: { keyword: '', page: 1 }
+        end
+
+        it '200 OKを返却すること' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it '全てのレシピを返却すること' do
+          expect(response.parsed_body.length).to eq 3
+        end
+      end
+
+      context 'キーワードがnullの時' do
+        before do
+          get '/api/v1/recipes/search', params: { page: 1 }
+        end
+
+        it '422 Unprocessable Entityを返却すること' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it '適切なエラーメッセージを返却すること' do
+          expect(response.parsed_body).to include('error' => '不正なパラメータです。')
+        end
+      end
+    end
+
+    context '該当するレシピが存在しない時' do
+      before do
+        create(:recipe, user:, name: 'パスタ')
+        create(:recipe, user:, name: 'カレー')
+        create(:recipe, user:, name: 'ハンバーグ')
+        get '/api/v1/recipes/search', params: { keyword: 'グラタン', page: 1 }
+      end
+
+      it '200を返却すること' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'レスポンスは空の配列を返却すること' do
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'ページネーションが適用されるとき' do
+      before do
+        create_list(:recipe, 11, user:, name: 'テストレシピ')
+      end
+
+      it '1ページ目は最大10件のアイテムを返却すること' do
+        get '/api/v1/recipes/search', params: { keyword: 'テストレシピ', page: 1 }
+        expect(response.parsed_body.length).to eq 10
+      end
+
+      it '2ページ目が正しい数のアイテムを返却すること' do
+        get '/api/v1/recipes/search', params: { keyword: 'テストレシピ', page: 2 }
+        expect(response.parsed_body.length).to eq 1
+      end
+
+      it '0がページ番号として与えられたときに200を返却すること' do
+        create_list(:recipe, 10, user:, name: 'テストレシピ')
+
+        get '/api/v1/recipes/search', params: { keyword: 'テストレシピ', page: 0 }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '一般シェフユーザーが作成したレシピ' do
+      let(:user) { create(:user, user_type: 'user') }
+
+      before do
+        create(:recipe, user:, name: 'パスタグラタン')
+        create(:recipe, user:, name: 'カレーグラタン')
+        create(:recipe, user:, name: 'ハンバーグ')
+        get '/api/v1/recipes/search', params: { keyword: 'グラタン', page: 1 }
+      end
+
+      it 'chefタイプのユーザー以外のレシピは含まれないこと' do
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context '非公開のレシピが含まれているとき' do
+      before do
+        create(:recipe, user:, name: 'パスタグラタン')
+        create(:recipe, user:, name: 'カレーグラタン')
+        create(:recipe, user:, name: 'ハンバーググラタン', is_public: false)
+        get '/api/v1/recipes/search', params: { keyword: 'グラタン', page: 1 }
+      end
+
+      it '非公開のレシピは検索結果に含まれないこと' do
+        expect(response.parsed_body.length).to eq 2
+      end
+    end
+  end
 end


### PR DESCRIPTION
## このプルリクエストで何をしたのか

## 対象issue
<!-- 例) close #12 -->
close #85 

## 重点的に見てほしいところ(不安なところ)

### 仕様面について
- 検索ワードが無い場合、話題のレシピと同じ表示にする（figma参考）
- 1ページ10件（とりあえず）

## 後回しにしたところ

## 参考情報

## 備考
