### PR TITLE
impl: マイレシピ編集エンドポイントを実装

### DIFF
--- a/app/controllers/api/v1/my_recipes_controller.rb
+++ b/app/controllers/api/v1/my_recipes_controller.rb
@@ -1,8 +1,21 @@
 class Api::V1::MyRecipesController < Api::V1::ApplicationBaseController
+  before_action :set_recipe
+
   def show
-    @recipe = Recipe.find(params[:id])
     # TODO: recipe.userとログインユーザーが同じかどうかをチェックする
     #       recipeのis_publicがfalse かつ recipe.userとログインユーザーが異なる場合、403 Forbiddenの例外を出す
     #       https://github.com/qin-team-recipe/01-backend/issues/133のIssueで対応する
+  end
+
+  def edit
+    # TODO: recipe.userとログインユーザーが同じかどうかをチェックする
+    #       recipeのis_publicがfalse かつ recipe.userとログインユーザーが異なる場合、403 Forbiddenの例外を出す
+    #       https://github.com/qin-team-recipe/01-backend/issues/133のIssueで対応する
+  end
+
+  private
+
+  def set_recipe
+    @recipe = Recipe.find(params[:id])
   end
 end

--- a/app/controllers/api/v1/my_recipes_controller.rb
+++ b/app/controllers/api/v1/my_recipes_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::MyRecipesController < Api::V1::ApplicationBaseController
   before_action :set_recipe
+  before_action :check_request_ids_params
 
   def show
     # TODO: recipe.userとログインユーザーが同じかどうかをチェックする
@@ -17,5 +18,9 @@ class Api::V1::MyRecipesController < Api::V1::ApplicationBaseController
 
   def set_recipe
     @recipe = Recipe.find(params[:id])
+  end
+
+  def check_request_ids_params
+    raise ActionController::BadRequest unless params[:user_id].to_i == @recipe.user_id
   end
 end

--- a/app/views/api/v1/my_recipes/edit.json.jbuilder
+++ b/app/views/api/v1/my_recipes/edit.json.jbuilder
@@ -1,0 +1,21 @@
+json.id @recipe.id
+json.name @recipe.name
+json.description @recipe.description
+json.thumbnail @recipe.thumbnail
+json.is_draft @recipe.is_draft
+json.is_public @recipe.is_public
+json.serving_size @recipe.serving_size
+json.steps @recipe.steps do |step|
+  json.description step.description
+  json.position step.position
+end
+json.materials @recipe.materials do |material|
+  json.name material.name
+  json.position material.position
+end
+json.external_links @recipe.recipe_external_links do |external_link|
+  json.url external_link.url
+  json.type external_link.url_type
+end
+json.created_at @recipe.created_at
+json.updated_at @recipe.updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
       resources :users do
         resources :cart_lists, only: %i[index]
-        resources :my_recipes, only: %i[show]
+        resources :my_recipes, only: %i[show edit]
 
         member do
           get :popular_recipes, to: 'recipes#user_popular_recipes'

--- a/spec/requests/my_recipes_spec.rb
+++ b/spec/requests/my_recipes_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe 'MyRecipes' do
                                                 })
       end
     end
+
+    context 'リクエストされたuser_idとrecipe_idに整合性がない場合' do
+      let!(:recipe) { create(:recipe, :with_user) }
+      let!(:another_user) { create(:user) }
+
+      it '400を返却すること' do
+        get api_v1_user_my_recipe_path(another_user, recipe)
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
   end
 
   describe 'GET /users/:user_id/my_recipes/:id/edit' do
@@ -84,6 +94,16 @@ RSpec.describe 'MyRecipes' do
                                                   'created_at' => recipe.created_at.iso8601(3),
                                                   'updated_at' => recipe.updated_at.iso8601(3)
                                                 })
+      end
+    end
+
+    context 'リクエストされたuser_idとrecipe_idに整合性がない場合' do
+      let!(:recipe) { create(:recipe, :with_user) }
+      let!(:another_user) { create(:user) }
+
+      it '400を返却すること' do
+        get edit_api_v1_user_my_recipe_path(another_user, recipe)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/requests/my_recipes_spec.rb
+++ b/spec/requests/my_recipes_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'MyRecipes' do
-  describe 'GET /recipes/:id' do
+  describe 'GET /users/:user_id/my_recipes/:id' do
     context 'レシピのレコードがあるとき' do
       let!(:recipe) { create(:recipe, :with_user) }
       let!(:step) { create(:step, recipe:) }
@@ -27,6 +27,48 @@ RSpec.describe 'MyRecipes' do
                                                   'is_public' => recipe.is_public,
                                                   'is_draft' => recipe.is_draft,
                                                   'author_type' => recipe.author_type,
+                                                  'steps' => [
+                                                    'description' => step.description,
+                                                    'position' => step.position
+                                                  ],
+                                                  'materials' => [
+                                                    'name' => material.name,
+                                                    'position' => material.position
+                                                  ],
+                                                  'external_links' => [
+                                                    'type' => recipe_external_link.url_type,
+                                                    'url' => recipe_external_link.url
+                                                  ],
+                                                  'created_at' => recipe.created_at.iso8601(3),
+                                                  'updated_at' => recipe.updated_at.iso8601(3)
+                                                })
+      end
+    end
+  end
+
+  describe 'GET /users/:user_id/my_recipes/:id/edit' do
+    context 'レシピのレコードがあるとき' do
+      let!(:recipe) { create(:recipe, :with_user) }
+      let!(:step) { create(:step, recipe:) }
+      let!(:material) { create(:material, recipe:) }
+      let!(:recipe_external_link) { create(:recipe_external_link, :with_url_type, recipe:) }
+
+      it '200を返却すること' do
+        get edit_api_v1_user_my_recipe_path(recipe.user, recipe)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'recipeのレコードを返却すること' do
+        get edit_api_v1_user_my_recipe_path(recipe.user, recipe)
+
+        expect(response.parsed_body).to include({
+                                                  'id' => recipe.id,
+                                                  'name' => recipe.name,
+                                                  'description' => recipe.description,
+                                                  'thumbnail' => recipe.thumbnail,
+                                                  'is_draft' => recipe.is_draft,
+                                                  'is_public' => recipe.is_public,
+                                                  'serving_size' => recipe.serving_size,
                                                   'steps' => [
                                                     'description' => step.description,
                                                     'position' => step.position


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- マイレシピ編集エンドポイントを実装しました
- リクエストに渡されるuser_idとrecipe_idが正しいかどうかをチェックするようにしました

## 対象issue
<!-- 例) close #12 -->
close #65
Notion: https://www.notion.so/users-user_id-recipes-recipe_id-edit-5a8217d8c8cc4f8d9fe9335817f86279

## 重点的に見てほしいところ(不安なところ)
controllerに実装した`check_request_ids_params`というメソッドがちょっといけてないなあと思ったんですがどうですか？

## 後回しにしたところ

## 参考情報

## 備考
