### PR TITLE
mod: seedでCartListのじぶんノートを作らないようにした

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,8 +29,8 @@
     recipe_id: recipe.id,
     user_id: user.id,
     name: Faker::Lorem.sentence(word_count: 5),
-    position: rand(1..10),
-    own_notes: [true, false].sample
+    position: rand(2..10),
+    own_notes: false
   )
 
   recipe_external_link = RecipeExternalLink.create!(


### PR DESCRIPTION
## このプルリクエストで何をしたのか
Renderにデプロイした際に、レコードが0になってしまった
もう一度seedを実行したいものの、現在seedを実行するとエラーになるのでそれを解消した。

エラーになる原因:
CartListに対して、positionが1のもの、own_notesがtrueのもの（いわゆるじぶんノート）は重複しないようなバリデーションを追加したため。
じぶんノートはUserのレコードを作る際にコールバックで自動的に作成されるため、Seedで作成するとバリデーションエラーとなる。

## 対象issue

## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ

## 参考情報

## 備考
